### PR TITLE
Correction d'un retour de ligne en millieu de phrase

### DIFF
--- a/Politique/PolitiqueDuLibre.md
+++ b/Politique/PolitiqueDuLibre.md
@@ -18,7 +18,7 @@ Les objectifs de la présente politique sont les suivants :
   les employés de la Ville ainsi que ses fournisseurs;
 * Contribuer à l'augmentation de la qualité et de la sécurité des solutions offertes;
 * Favoriser la réutilisation des solutions technologiques développées par ou pour la
-* Ville et en particulier faciliter le partage avec les administrations publiques;
+  Ville et en particulier faciliter le partage avec les administrations publiques;
 * Stimuler l’innovation et la concurrence des marchés;
 * Fournir des solutions modernes et adaptées aux citoyens;
 * Contribuer au bien commun.


### PR DESCRIPTION
J'ai découvert qu'un des éléments de la section "Objectifs" était coupé sur deux lignes. 

Cette petite modification enlève le point qui apparait au millieu de la phrase