### PR TITLE
Feature/revert partiel des directives

### DIFF
--- a/Directives/ContributionAProjetLibre.md
+++ b/Directives/ContributionAProjetLibre.md
@@ -1,16 +1,16 @@
 [English](#english-version)
 
-# Directive de contribution à un projet libre existant
+# Directive de contribution à un projet libre
 
 ## Introduction
 Suivant sa politique sur l’utilisation et le développement des logiciels
 et du matériel libres, la Ville de Montréal sera amenée à contribuer à
 des projets libres existants. Ces contributions seront faites dans deux
-buts majeurs:
-  1. réparer des bogues dans le projet pour en permettre une meilleure
+buts principaux :
+  1. réparer des bogues au produit pour en permettre une meilleure
 utilisation par la Ville et par la communauté,
-  1. ajouter des fonctionnalités au projet pour répondre aux besoins de
-la Ville et de la communauté.
+  1. ajouter des fonctionnalités au produit pour répondre aux besoins de
+la Ville et/ou de la communauté.
 
 Le présent document décrit les grandes lignes du processus à suivre
 afin de contribuer à un projet libre existant.
@@ -29,7 +29,7 @@ pour la Ville à des projets libres existants.
 ## Définitions
 **Contrat de licence du contributeur *(Contributor License Agreement)*
 (*CLA*)**: Accord entre un contributeur et l’entité juridique gérant un
-projet libre, permettant de contribuer de la propriété intellectuelle
+projet libre permettant de contribuer de la propriété intellectuelle
 à cedit projet.
 
 **Contributeur**: Personne faisant une contribution à un projet libre.
@@ -52,7 +52,7 @@ dispositifs ou toutes choses physiques) ayant été rendus publics de façon
 artéfacts.
 
 **Propriété intellectuelle**: Droits légaux quant à des créations
-intellectuelles par exemple un logiciel ou des plans de matériels.
+intellectuelles tel que des artéfacts logiciels ou des plans de matériels.
 
 **Responsable du projet (*Maintainer*)**: Personne responsable de
 l'exécution de l'ensemble des opérations qui sont jugées nécessaires
@@ -65,9 +65,8 @@ de la Ville de Montréal, les projets libres auxquels contribue la Ville
 ne doivent pas être en conflit avec lesdites valeurs.
 
 Avant une toute première contribution à un projet libre, une **permission
-globale devra être obtenue** du directeur du service des TI, ou de son
-délégué, afin de s’assurer que le projet en question est compatible
-avec les valeurs de la Ville.
+globale devra être obtenue** du Comité du libre afin de s’assurer que le
+projet en question est compatible avec les valeurs de la Ville.
 
 Si un projet libre est approuvé, cette permission sera applicable à
 toutes contributions futures.
@@ -75,9 +74,9 @@ toutes contributions futures.
 La permission globale sera permanente, à moins d’un changement majeur
 de la réalité du projet libre qui contreviendrait aux valeurs de la Ville.
 
-Un fichier est maintenu répertoriant les projets ayant obtenu une
-permission globale de contribution. Ce fichier fait partie de ce dépôt sous
-le répertoire `Approbations`.
+Il est possible de déterminer si un projet est déjà approuvé en vérifiant
+si un *fork* du projet existe déjà dans l'organisation GitHub de
+la [VilleDeMontreal](https://github.com/VilledeMontreal).
 
 ## Propriété intellectuelle
 Toutes modifications apportées à un projet libre par un employé ou un
@@ -118,20 +117,12 @@ utilisant une adresse courriel personnelle.
 ### Droits de contribution
 Dans tous les cas de contributions, et même si ce n’est pas explicitement
 requis par le projet libre en question, le contributeur doit s’assurer que
-la Ville de Montréal possède les droits vis-à-vis de toutes les modifications.
-Pour cela, le contributeur doit confirmer que:
-
-  1. **la contribution a été rédigée en tout ou en partie par le contributeur
-  et qu’il/elle a les droits de publier la contribution sous la licence libre
-  requise**;<br>
-  ***OU***
-  1. **la contribution a été fournie au contributeur par une autre personne
-  qui certifie la clause #1, et que cette contribution n’a pas été modifiée
-  depuis.**
+la Ville de Montréal possède les droits vis-à-vis toutes les modifications.
+Pour cela, le contributeur doit confirmer **qu’il a les droits de publier
+la contribution sous la licence libre requise**.
 
 Si le projet requiert un contrat de licence du contributeur (*CLA*), ce dernier
-devra être signé par la personne concernée.  Dans la majorité des cas, le *CLA*
-devra être signé par le directeur des STI.
+devra être signé par le directeur du Service des TI.
 
 **La validation et l’approbation du *CLA* doivent être incluses à la permission
 de contribution décrite plus haut.**
@@ -147,29 +138,24 @@ doivent être incluses à la permission de contribution décrite plus haut.**
 
 ## Licence
 Tout nouveau fichier à contribuer devra utiliser la licence requise par le
-projet en question.  La licence est souvent incluse au haut du fichier dans
+projet en question. La licence est souvent incluse au haut du fichier dans
 le cas de fichiers texte, mais cela peut dépendre du projet en question.
 
 Une licence différente est souvent requise pour les composantes de nature
 non logicielles ou non matérielles, telles les images, la documentation, les
-bases de données.  La licence à utiliser sera celle déjà sélectionnée par le
-projet pour le type de composante en question; si le choix de cette licence
-n’a pas encore été fait par le projet, il devra être fait par un des
-responsables du projet.
+bases de données. La licence à utiliser sera celle sélectionnée par le
+projet pour le type de composante en question.
 
 ## Information sensible
 Toute contribution doit respecter la Loi sur la protection des renseignements
-personnels du Québec; ne pas nuire à la protection de la vie privée, à la
-sécurité publique ou à la sécurité de l’information de la Ville de Montréal.
+personnels du Québec et ne pas nuire à la protection de la vie privée,
+à la sécurité publique ou à la sécurité de l’information de la Ville de Montréal.
 
 Il est de la responsabilité du contributeur de s’assurer que sa contribution
 ne contient pas ce type d’information.
 
-Une liste non-exhaustive d’exceptions est fournie:
-
-- ***À REMPLIR***
-
 ## Code de conduite
+
 Les contributions faites au nom de la Ville de Montréal affectent
 potentiellement la réputation de la Ville. Il est important de protéger
 cette réputation pour préserver l’image de la Ville.
@@ -191,13 +177,26 @@ Pour cela:
   technique.  Une revue de la contribution par des pairs, avant sa soumission au
   projet, est recommandée afin d’assurer la qualité de la contribution.
 
-## Application de la directive
-Les étapes à suivre pour faire une contribution à un projet existants sont:
+Le [Code de Conduite](http://ville.montreal.qc.ca/pls/portal/docs/page/intra_fr/media/documents/code_conduite_employes.pdf)
+des employés de la Ville de Montréal s'applique à toutes interactions relatives aux projets libres.
 
+## Application de la directive
+Les étapes à suivre pour faire une contribution à un projet existants sont illustrées dans
+[ce diagramme](https://www.lucidchart.com/publicSegments/view/5790e4bb-e4d7-46d2-99ea-5412cad7dad6).
+
+Le processus complet est détaillé par les étapes suivantes :
 1. Identifier un besoin de contribution à un projet libre.
 1. Vérifier si le projet est déjà approuvé pour des contributions de la Ville
-ou débuter le processus d’approbation, incluant la signature du *CLA* si
-nécessaire;
+ou débuter le processus d’approbation :
+    1. Envoyer conjointement avec un Architecte de solutions une demande au Comité du libre à l'adresse courriel du comité (libre@ville.montreal.qc.ca) contenant les informations suivantes :
+        * Le projet faisant l'objet d'une contribution
+            * Le lien officiel du dépot du projet
+            * La license libre utilisée par le projet
+            * Si un CLA (Contributor License Agreement) doit être signé pour contribuer au projet
+        * Le projet Ville auquel la contribution est reliée
+        * La nature de la contribution (nouvelle fonctionnalité, correction de bogues, documentation, etc.)
+        * Toute information jugée pertinente
+
 1. Se familiariser avec le processus de contribution du projet:
     1. Lire le document README et CONTRIBUTING du projet, si présents, afin de
 comprendre le processus de contribution;
@@ -220,7 +219,7 @@ complétées.
 
 <a id='english-version' class='anchor' aria-hidden='true'/>
 
-# Directive on Contributing to an Existing Open-Source Project
+# Directive on Contributing to an Open-Source Project
 
 ## Introduction
 
@@ -228,7 +227,7 @@ Under its open-source software/hardware development and usage policy, the Ville 
 Montréal may contribute to existing open-source projects. Such contributions respond to
 two key goals:
 1. Eliminating bugs, to permit better use by the City and community.
-1. Adding project features, to meet municipal and community needs.
+1. Adding product features, to meet municipal and community needs.
 
 This document outlines the procedure for contributing to an existing open-source project.
 
@@ -244,7 +243,7 @@ contributions to existing open-source projects for the City.
 ## Definitions
 
 **Contributor License Agreement/CLA**: Agreement between a contributor and the legal
-entity overseeing an open-source project, permitting contributions to the project’s
+entity overseeing an open-source project permitting contributions to the project’s
 intellectual property.
 
 **Contributor**: Person contributing to an open-source project.
@@ -265,7 +264,7 @@ any physical object) that have been made public so that anyone can manufacture,
 modify, distribute or use such artifacts.
 
 **Intellectual property**: Legal rights to intellectual creations, such as hardware plans
-or software.
+or software artifacts.
 
 **Maintainer**: Person responsible for performing any operation considered necessary to
 ensure the proper operation of an open-source software or hardware project, according to
@@ -276,8 +275,8 @@ established specifications.
 Open-source projects to which the Ville de Montréal contributes must comply with the
 City’s principles of integrity, respect and loyalty.
 
-**Global permission must be obtained** from the City’s director of IT services or the
-latter’s delegate, before making an initial contribution to an open-source project, to
+**Global permission must be obtained** from the Open-Source Committee
+before making an initial contribution to an open-source project, to
 ensure that the project is consistent with municipal values.
 
 If an open-source project is approved, such permission will extend to all future
@@ -286,9 +285,8 @@ contributions.
 Global permission is permanent, unless there is a major change that brings the project
 into conflict with municipal values.
 
-The City maintains a list of the projects that have received a global permission for
-contributions. This list is part of this repository and can be found in the `Approbations`
-folder.
+One can determine if a projet has already been approved for contributions by looking
+if a fork of the project exists in the GitHub organization [VilleDeMontreal](https://github.com/VilledeMontreal).
 
 ## Intellectual Property
 
@@ -323,17 +321,12 @@ All individual contributions must be made using a personal email address.
 ### Contribution Rights
 
 For all contributions, even where not explicitly required by the open-source project concerned,
-the contributor must ensure that the City holds the rights to any changes. The contributor
-does so by confirming that:
+the contributor must ensure that the City holds the intellectual rights to any changes. The
+contributor does so by confirming that ** he has the rights to publish the contribution under
+the required open-source licence**.
 
-  1. **The contribution was written in whole or part by the contributor who holds the rights
-  to publish the contribution under the required open-source licence.**;<br>
-  ***OR***
-  1. **The contribution was provided to the contributor by another person who certifies
-  compliance with Clause #1, and that this contribution has not been altered subsequently.**
-
-If the project requires a contributor licence agreement (CLA), it must be signed by the person
-concerned. In most cases, the CLA must be signed by the director of IT.
+If the project requires a contributor licence agreement (CLA), it must be signed by
+the director of IT.
 
 **CLA validation and approval must be included in the contribution permission described above.**
 
@@ -354,20 +347,15 @@ by project.
 
 A different licence is often required for components other than software or hardware, such as
 images, documentation and databases. The licence to be used will be the kind already selected
-by the project for the type of component concerned. One of the project supervisors must select
-the licence type if this has not already been done by the project.
+by the project for the type of component concerned.
 
 ## Sensitive Information
 
-All contributions must comply with Québec’s Privacy Act, and must not jeopardize privacy, public
-safety or the security of the information of the Ville de Montréal.
+All contributions must comply with Québec’s Privacy Act, and must not jeopardize privacy,
+public safety or the security of the information of the Ville de Montréal.
 
 Contributors are responsible for ensuring that their contributions do not contain such
 information.
-
-A partial list of exceptions follows:
-
-- ***TO BE PROVIDED***
 
 ## Code of Conduct
 
@@ -391,13 +379,27 @@ of the other parties’ attitude.
 contribution, prior to its submission to the project, is recommended to ensure the
 contribution’s quality.
 
+The City employees'
+[Code of conduct](http://ville.montreal.qc.ca/pls/portal/docs/page/intra_fr/media/documents/code_conduite_employes.pdf)
+applies to all interactions pertaining to open source projects.
+
 ## Application of Directive
 
-The steps involved in contributing to an existing project are:
+The steps involved in contributing to an existing project are shown in
+[this diagram](https://www.lucidchart.com/publicSegments/view/5790e4bb-e4d7-46d2-99ea-5412cad7dad6).
 
+The complete process is detailed below:
 1. Identifying a need for a contribution to an open-source project.
 1. Checking if the project has already been approved for municipal contributions
-or initiate the approval process and obtain the CLA’s signature, if necessary.
+or initiate the approval process:
+    1. Jointly with a Solutions Architect, send a request to the Open-Source Committee at libre@ville.montreal.qc.ca with the following information:
+        * The open-source project for which the contribution will be made
+            * URL of the project
+            * Licence used by the project
+            * If a CLA must be signed to contribute to the project
+        * The City project associated with the contribution
+        * The type of contribution (new functionality, bug fix, documentation, etc) 
+        * Any other relevant information
 1. Acquainting yourself with the project contribution process:
     1. Reading the project’s README and CONTRIBUTING documents, if available, to
 understand the contribution process.

--- a/Directives/ContributionAProjetLibre.md
+++ b/Directives/ContributionAProjetLibre.md
@@ -1,16 +1,16 @@
 [English](#english-version)
 
-# Directive de contribution à un projet libre
+# Directive de contribution à un projet libre existant
 
 ## Introduction
 Suivant sa politique sur l’utilisation et le développement des logiciels
 et du matériel libres, la Ville de Montréal sera amenée à contribuer à
 des projets libres existants. Ces contributions seront faites dans deux
-buts principaux :
-  1. réparer des bogues au produit pour en permettre une meilleure
+buts majeurs:
+  1. réparer des bogues dans le projet pour en permettre une meilleure
 utilisation par la Ville et par la communauté,
-  1. ajouter des fonctionnalités au produit pour répondre aux besoins de
-la Ville et/ou de la communauté.
+  1. ajouter des fonctionnalités au projet pour répondre aux besoins de
+la Ville et de la communauté.
 
 Le présent document décrit les grandes lignes du processus à suivre
 afin de contribuer à un projet libre existant.
@@ -29,7 +29,7 @@ pour la Ville à des projets libres existants.
 ## Définitions
 **Contrat de licence du contributeur *(Contributor License Agreement)*
 (*CLA*)**: Accord entre un contributeur et l’entité juridique gérant un
-projet libre permettant de contribuer de la propriété intellectuelle
+projet libre, permettant de contribuer de la propriété intellectuelle
 à cedit projet.
 
 **Contributeur**: Personne faisant une contribution à un projet libre.
@@ -52,7 +52,7 @@ dispositifs ou toutes choses physiques) ayant été rendus publics de façon
 artéfacts.
 
 **Propriété intellectuelle**: Droits légaux quant à des créations
-intellectuelles tel que des artéfacts logiciels ou des plans de matériels.
+intellectuelles par exemple un logiciel ou des plans de matériels.
 
 **Responsable du projet (*Maintainer*)**: Personne responsable de
 l'exécution de l'ensemble des opérations qui sont jugées nécessaires
@@ -65,8 +65,9 @@ de la Ville de Montréal, les projets libres auxquels contribue la Ville
 ne doivent pas être en conflit avec lesdites valeurs.
 
 Avant une toute première contribution à un projet libre, une **permission
-globale devra être obtenue** du Comité du libre afin de s’assurer que le
-projet en question est compatible avec les valeurs de la Ville.
+globale devra être obtenue** du directeur du service des TI, ou de son
+délégué, afin de s’assurer que le projet en question est compatible
+avec les valeurs de la Ville.
 
 Si un projet libre est approuvé, cette permission sera applicable à
 toutes contributions futures.
@@ -74,9 +75,9 @@ toutes contributions futures.
 La permission globale sera permanente, à moins d’un changement majeur
 de la réalité du projet libre qui contreviendrait aux valeurs de la Ville.
 
-Il est possible de déterminer si un projet est déjà approuvé en vérifiant
-si un *fork* du projet existe déjà dans l'organisation GitHub der
-la [VilleDeMontreal](https://github.com/VilledeMontreal).
+Un fichier est maintenu répertoriant les projets ayant obtenu une
+permission globale de contribution. Ce fichier fait partie de ce dépôt sous
+le répertoire `Approbations`.
 
 ## Propriété intellectuelle
 Toutes modifications apportées à un projet libre par un employé ou un
@@ -117,12 +118,20 @@ utilisant une adresse courriel personnelle.
 ### Droits de contribution
 Dans tous les cas de contributions, et même si ce n’est pas explicitement
 requis par le projet libre en question, le contributeur doit s’assurer que
-la Ville de Montréal possède les droits vis-à-vis toutes les modifications.
-Pour cela, le contributeur doit confirmer **qu’il a les droits de publier
-la contribution sous la licence libre requise**.
+la Ville de Montréal possède les droits vis-à-vis de toutes les modifications.
+Pour cela, le contributeur doit confirmer que:
+
+  1. **la contribution a été rédigée en tout ou en partie par le contributeur
+  et qu’il/elle a les droits de publier la contribution sous la licence libre
+  requise**;<br>
+  ***OU***
+  1. **la contribution a été fournie au contributeur par une autre personne
+  qui certifie la clause #1, et que cette contribution n’a pas été modifiée
+  depuis.**
 
 Si le projet requiert un contrat de licence du contributeur (*CLA*), ce dernier
-devra être signé par le directeur du Service des TI.
+devra être signé par la personne concernée.  Dans la majorité des cas, le *CLA*
+devra être signé par le directeur des STI.
 
 **La validation et l’approbation du *CLA* doivent être incluses à la permission
 de contribution décrite plus haut.**
@@ -138,20 +147,29 @@ doivent être incluses à la permission de contribution décrite plus haut.**
 
 ## Licence
 Tout nouveau fichier à contribuer devra utiliser la licence requise par le
-projet en question. La licence est souvent incluse au haut du fichier dans
+projet en question.  La licence est souvent incluse au haut du fichier dans
 le cas de fichiers texte, mais cela peut dépendre du projet en question.
 
 Une licence différente est souvent requise pour les composantes de nature
 non logicielles ou non matérielles, telles les images, la documentation, les
-bases de données. La licence à utiliser sera celle sélectionnée par le
-projet pour le type de composante en question.
+bases de données.  La licence à utiliser sera celle déjà sélectionnée par le
+projet pour le type de composante en question; si le choix de cette licence
+n’a pas encore été fait par le projet, il devra être fait par un des
+responsables du projet.
 
 ## Information sensible
 Toute contribution doit respecter la Loi sur la protection des renseignements
-personnels du Québec et ne pas nuire à la protection de la vie privée.
+personnels du Québec; ne pas nuire à la protection de la vie privée, à la
+sécurité publique ou à la sécurité de l’information de la Ville de Montréal.
+
+Il est de la responsabilité du contributeur de s’assurer que sa contribution
+ne contient pas ce type d’information.
+
+Une liste non-exhaustive d’exceptions est fournie:
+
+- ***À REMPLIR***
 
 ## Code de conduite
-
 Les contributions faites au nom de la Ville de Montréal affectent
 potentiellement la réputation de la Ville. Il est important de protéger
 cette réputation pour préserver l’image de la Ville.
@@ -173,26 +191,13 @@ Pour cela:
   technique.  Une revue de la contribution par des pairs, avant sa soumission au
   projet, est recommandée afin d’assurer la qualité de la contribution.
 
-Le [Code de Conduite](http://ville.montreal.qc.ca/pls/portal/docs/page/intra_fr/media/documents/code_conduite_employes.pdf)
-des employés de la Ville de Montréal s'applique à toutes interactions relatives aux projets libres.
-
 ## Application de la directive
-Les étapes à suivre pour faire une contribution à un projet existants sont illustrées dans
-[ce diagramme](https://www.lucidchart.com/publicSegments/view/5790e4bb-e4d7-46d2-99ea-5412cad7dad6).
+Les étapes à suivre pour faire une contribution à un projet existants sont:
 
-Le processus complet est détaillé par les étapes suivantes :
 1. Identifier un besoin de contribution à un projet libre.
 1. Vérifier si le projet est déjà approuvé pour des contributions de la Ville
-ou débuter le processus d’approbation :
-    1. Envoyer conjointement avec un Architecte de solutions une demande au Comité du libre à l'adresse courriel du comité (libre@ville.montreal.qc.ca) contenant les informations suivantes :
-        * Le projet faisant l'objet d'une contribution
-            * Le lien officiel du dépot du projet
-            * La license libre utilisée par le projet
-            * Si un CLA (Contributor License Agreement) doit être signé pour contribuer au projet
-        * Le projet Ville auquel la contribution est reliée
-        * La nature de la contribution (nouvelle fonctionnalité, correction de bogues, documentation, etc.)
-        * Toute information jugée pertinente
-
+ou débuter le processus d’approbation, incluant la signature du *CLA* si
+nécessaire;
 1. Se familiariser avec le processus de contribution du projet:
     1. Lire le document README et CONTRIBUTING du projet, si présents, afin de
 comprendre le processus de contribution;
@@ -215,7 +220,7 @@ complétées.
 
 <a id='english-version' class='anchor' aria-hidden='true'/>
 
-# Directive on Contributing to an Open-Source Project
+# Directive on Contributing to an Existing Open-Source Project
 
 ## Introduction
 
@@ -223,7 +228,7 @@ Under its open-source software/hardware development and usage policy, the Ville 
 Montréal may contribute to existing open-source projects. Such contributions respond to
 two key goals:
 1. Eliminating bugs, to permit better use by the City and community.
-1. Adding product features, to meet municipal and community needs.
+1. Adding project features, to meet municipal and community needs.
 
 This document outlines the procedure for contributing to an existing open-source project.
 
@@ -239,7 +244,7 @@ contributions to existing open-source projects for the City.
 ## Definitions
 
 **Contributor License Agreement/CLA**: Agreement between a contributor and the legal
-entity overseeing an open-source project permitting contributions to the project’s
+entity overseeing an open-source project, permitting contributions to the project’s
 intellectual property.
 
 **Contributor**: Person contributing to an open-source project.
@@ -260,7 +265,7 @@ any physical object) that have been made public so that anyone can manufacture,
 modify, distribute or use such artifacts.
 
 **Intellectual property**: Legal rights to intellectual creations, such as hardware plans
-or software artifacts.
+or software.
 
 **Maintainer**: Person responsible for performing any operation considered necessary to
 ensure the proper operation of an open-source software or hardware project, according to
@@ -271,8 +276,8 @@ established specifications.
 Open-source projects to which the Ville de Montréal contributes must comply with the
 City’s principles of integrity, respect and loyalty.
 
-**Global permission must be obtained** from the Open-Source Committee
-before making an initial contribution to an open-source project, to
+**Global permission must be obtained** from the City’s director of IT services or the
+latter’s delegate, before making an initial contribution to an open-source project, to
 ensure that the project is consistent with municipal values.
 
 If an open-source project is approved, such permission will extend to all future
@@ -281,8 +286,9 @@ contributions.
 Global permission is permanent, unless there is a major change that brings the project
 into conflict with municipal values.
 
-One can determine if a projet has already been approved for contributions by looking
-if a fork of the project exists in the GitHub organization [VilleDeMontreal](https://github.com/VilledeMontreal).
+The City maintains a list of the projects that have received a global permission for
+contributions. This list is part of this repository and can be found in the `Approbations`
+folder.
 
 ## Intellectual Property
 
@@ -317,12 +323,17 @@ All individual contributions must be made using a personal email address.
 ### Contribution Rights
 
 For all contributions, even where not explicitly required by the open-source project concerned,
-the contributor must ensure that the City holds the intellectual rights to any changes. The
-contributor does so by confirming that ** he has the rights to publish the contribution under
-the required open-source licence**.
+the contributor must ensure that the City holds the rights to any changes. The contributor
+does so by confirming that:
 
-If the project requires a contributor licence agreement (CLA), it must be signed by
-the director of IT.
+  1. **The contribution was written in whole or part by the contributor who holds the rights
+  to publish the contribution under the required open-source licence.**;<br>
+  ***OR***
+  1. **The contribution was provided to the contributor by another person who certifies
+  compliance with Clause #1, and that this contribution has not been altered subsequently.**
+
+If the project requires a contributor licence agreement (CLA), it must be signed by the person
+concerned. In most cases, the CLA must be signed by the director of IT.
 
 **CLA validation and approval must be included in the contribution permission described above.**
 
@@ -343,11 +354,20 @@ by project.
 
 A different licence is often required for components other than software or hardware, such as
 images, documentation and databases. The licence to be used will be the kind already selected
-by the project for the type of component concerned.
+by the project for the type of component concerned. One of the project supervisors must select
+the licence type if this has not already been done by the project.
 
 ## Sensitive Information
 
-All contributions must comply with Québec’s Privacy Act, and must not jeopardize privacy.
+All contributions must comply with Québec’s Privacy Act, and must not jeopardize privacy, public
+safety or the security of the information of the Ville de Montréal.
+
+Contributors are responsible for ensuring that their contributions do not contain such
+information.
+
+A partial list of exceptions follows:
+
+- ***TO BE PROVIDED***
 
 ## Code of Conduct
 
@@ -371,27 +391,13 @@ of the other parties’ attitude.
 contribution, prior to its submission to the project, is recommended to ensure the
 contribution’s quality.
 
-The City employees'
-[Code of conduct](http://ville.montreal.qc.ca/pls/portal/docs/page/intra_fr/media/documents/code_conduite_employes.pdf)
-applies to all interactions pertaining to open source projects.
-
 ## Application of Directive
 
-The steps involved in contributing to an existing project are shown in
-[this diagram](https://www.lucidchart.com/publicSegments/view/5790e4bb-e4d7-46d2-99ea-5412cad7dad6).
+The steps involved in contributing to an existing project are:
 
-The complete process is detailed below:
 1. Identifying a need for a contribution to an open-source project.
 1. Checking if the project has already been approved for municipal contributions
-or initiate the approval process:
-    1. Jointly with a Solutions Architect, send a request to the Open-Source Committee at libre@ville.montreal.qc.ca with the following information:
-        * The open-source project for which the contribution will be made
-            * URL of the project
-            * Licence used by the project
-            * If a CLA must be signed to contribute to the project
-        * The City project associated with the contribution
-        * The type of contribution (new functionality, bug fix, documentation, etc) 
-        * Any other relevant information
+or initiate the approval process and obtain the CLA’s signature, if necessary.
 1. Acquainting yourself with the project contribution process:
     1. Reading the project’s README and CONTRIBUTING documents, if available, to
 understand the contribution process.

--- a/Directives/PublicationProjetVille.md
+++ b/Directives/PublicationProjetVille.md
@@ -14,13 +14,20 @@ de publier un tel projet et de le maintenir.
 
 Cette directive s’adresse à l’ensemble des unités administratives de la
 Ville de Montréal susceptibles d’avoir à publier des projets logiciels
-ou matériels en tant que projets libres.
+ou matériels en tant que projet libres.
 
 Cette directive s’applique autant aux employés de la Ville qu’à ses
 contractants ou aux tierces parties appelées à publier des projets
 logiciels ou matériels au nom de la Ville, en tant que projets libres.
 
 ## Définitions
+**Contrat de licence du contributeur *(Contributor License Agreement)*
+(*CLA*)**: Accord entre un contributeur et l’entité juridique gérant un
+projet libre, permettant de contribuer de la propriété intellectuelle
+à cedit projet.
+
+**Contributeur**: Personne faisant une contribution à un projet libre.
+
 **Contribution**: Tout changement au code, à la documentation, aux
 fichiers de configuration, aux plans, ou à tout autre fichier d’un
 projet libre, qui est donné au projet en question pour y être inclus.
@@ -45,28 +52,43 @@ dispositifs ou toutes choses physiques) ayant été rendus publics de façon
 artéfacts.
 
 **Propriété intellectuelle**: Droits légaux quant à des créations
-intellectuelles tel que des artéfacts logiciels ou des plans de matériels.
+intellectuelles par exemple un logiciel ou des plans de matériels.
 
-**Publication libre**: Action de rendre un projet logiciel ou 
-matériel disponible au grand public.
+**Publication libre**: Les efforts et étapes initiaux nécessaires
+à rendre un projet logiciel ou matériel disponible au grand public.
 
 **Responsable du projet (*Maintainer*)**: Personne responsable de
 l'exécution de l'ensemble des opérations qui sont jugées nécessaires
 pour garantir le bon fonctionnement d'un projet de logiciel ou matériel
 libres, conformément à des spécifications définies.
 
+## Permissions de publication
+Afin de protéger les intérêts et les ressources de la Ville, il faut
+que les bénéfices, les risques et les coûts soient évalués avant la
+publication libre d’un projet logiciel ou matériel.  Lorsque l’unité
+d’affaires juge appropriée la publication libre d’un projet, une
+permission devra être obtenue du directeur du service des TI, ou de
+son délégué.  Cette permission vise à assurer que les bénéfices de
+la publication libre sont compatibles avec les valeurs de la Ville.
+
+La permission sera obtenue suite à la présentation et l’acceptation
+d’un dossier contenant au minimum les éléments suivants :
+1. la raison d’être du produit;
+1. la vigie de marché démontrant le manque à combler s’il y a lieu,
+ou les avantages de créer un marché ouvert parallèle;
+1. les risques potentiels,
+1. les coûts à prévoir (nombre d’employés affectés aux projet,
+tâches requises pour le maintien du projet après sa publication,
+estimation de la durée de la participation, etc.).
+
 ## Publication
-
-Lorsque l’unité d’affaires juge appropriée la publication libre d’un projet,
-une consultation du Comité du Libre est nécessaire afin d'entamer la
-publication du projet.
-
-La publication en libre sera faite dans l'organisation GitHub de la Ville.
 
 ### Propriété intellectuelle
 
 Afin de pouvoir publier librement un projet logiciel au nom de la
-Ville, un responsable du projet doit:
+Ville, un responsable du projet doit s’assurer que la Ville détient
+les droits légaux nécessaires à une telle publication.  Pour cela,
+le responsable du projet doit:
 1. s’assurer que tout fichier faisant partie de la publication est,
 de façon exclusive, la propriété intellectuelle de la Ville;<br>
 ou,
@@ -86,22 +108,56 @@ un projet logiciel existant.
 La publication de projet sera faite dans GitHub sous le compte de la 
 Ville: github.com/villedemontreal
 
-### Responsable du projet libre
+### Responsables du projet
 
-Avant la publication, un responsable du projet libre doit être désigné.
-Un responsable devrait normalement avoir une connaissance des détails
-du projet et pourra en gérer le code et autres aspects. Le role d’un
-responsable est d'accompagner le projet dans son évolution
-en libre afin que la Ville puisse bénéficier des avantages de la
-publication.
+Avant la publication, un ou plusieurs responsables du projet doivent
+être désignés.  Un responsable devrait normalement avoir une connaissance
+approfondie des détails du projet et pourra en gérer le code et autres
+aspects.  Le mandat d’un responsable du projet est d’assurer l’évolution
+du projet afin que la Ville puisse bénéficier des avantages de la
+publication en libre.
 
-### Licences
-Tout code du projet publié en libre utilisera la licence *MIT*. Un ficher LICENSE
-tel que défini dans l’appendice A, doit être mis dans le répertoire de base du
+Il est recommandé de désigner plus d’un responsable afin d’assurer le
+maintien du projet.
+
+Durant la vie du projet, de nouveaux responsables peuvent être nommés
+après qu’ils aient démontré les compétences nécessaires pour assurer ce rôle.  Une
+telle nomination doit être appuyée par au moins un responsable existant,
+sans être refusée par aucun autre responsable du projet.  Après une
+nomination approuvée, un nouveau responsable se verra accorder les mêmes
+droits que les responsables existants. Une personne mise en nomination en
+tant que responsable, peut aussi bien être associée à la Ville qu’être un
+contributeur externe, sans aucune association à la Ville.  
+
+Un responsable du projet peut en tout temps abandonner officiellement son
+rôle.  Dans un tel cas, il convient d’avertir le reste de la communauté du
+projet, et d’assurer une transition de responsabilité, si nécessaire.
+
+### Identité à utiliser pour la publication
+
+La publication libre d’un projet sera faite par un des responsables du
+projet qui a été assigné.  Cette publication doit être faite en utilisant
+le nom dudit responsable ainsi que son adresse courriel fournie par la Ville.
+Toutes modifications faites au nom de la Ville, après la publication du projet,
+doivent aussi être faites en utilisant l’adresse courriel fournie par la Ville.
+
+L’utilisation de l’adresse courriel de la Ville permet de distinguer les
+contributions faites au nom de la Ville et de celles réalisées en dehors des
+heures de travail (non rémunérées par la Ville).
+
+Toutes contributions pour lesquelles la Ville possède la propriété intellectuelle
+doivent être faites par un employé ou un contractant à l’emploi de la Ville.
+
+Toutes contributions faites de façon personnelle doivent être faites en utilisant
+une adresse courriel personnelle.
+
+### Licence
+Tout code du projet publié en libre utilisera la licence MIT. Un ficher LICENSE.md
+tel que définit dans l’appendice A, doit être mis dans le répertoire de base du
 projet, et ce, dès la publication initiale.
 
 Pour les autres composantes du projet, tel les images et la documentation, une des
-licences *Creative Commons* sera utilisée.
+licences Creative Commons sera utilisée.
 
 Pour les bases de données, la licence *Open Data Commons Open Database License (ODbL)*
 sera utilisée (voir l’appendice A).
@@ -109,28 +165,108 @@ sera utilisée (voir l’appendice A).
 ### Information sensible
 
 Une publication libre d’un projet doit respecter la Loi sur la protection des
-renseignements personnels du Québec et ne pas nuire à la protection de la vie privée.
+renseignements personnels du Québec; ne pas nuire à la protection de la vie privée
+à la sécurité publique ou à la sécurité de l’information de la Ville de Montréal.
+
+Il est de la responsabilité du responsable de projet faisant la publication de
+s’assurer que le projet à publier ne contient pas ce type d’information.
+
+Une liste non-exhaustive d’exceptions est fournie:
+
+- ***À REMPLIR***
+
+## Contributions
+
+Un projet libre est appelé à évoluer après sa publication. Des contributions,
+autant internes (de la Ville) qu’externes (d’un contributeur non associé à la Ville)
+seront reçues afin de réparer des bogues ou d’ajouter des fonctionnalités.  Ces
+contributions doivent être gérées de façon adéquate.
+
+Il est de la responsabilité d’un responsable du projet de gérer et d’accepter ou
+refuser une contribution.
+
+### Bonnes pratiques pour contributions
+
+Les responsables du projet définissent les étapes à suivre pour faire une
+contribution au projet.  Un fichier CONTRIBUTING.md, doit être mis dans le
+répertoire de base du projet.  Les bonnes pratiques de contribution sont spécifiques
+à un projet et à ses responsables.  Des exemples de fichier CONTRIBUTING.md peuvent
+servir d’inspiration:
+* github.com/dotnet/corefx/blob/master/Documentation/project-docs/contributing.md
+* github.com/angular/angular.js/blob/master/CONTRIBUTING.md
+* github.com/robbyrussell/oh-my-zsh/blob/master/CONTRIBUTING.md
+* github.com/facebook/react/blob/master/CONTRIBUTING.md
+
+### Licence
+
+Chaque composante faisant partie d’une contribution devra utiliser la licence appropriée
+comme définie plus haut. 
+
+### Contrat de licence du contributeur (*Contributor License Agreement - CLA*)
+Dans tous les cas de contributions, un responsable du projet doit s’assurer que la personne
+effectuant la contribution possède les droits nécessaires vis-à-vis de toutes les
+modifications soumises.  Pour cela, le contributeur doit confirmer explicitement que:
+
+  1. **la contribution a été rédigée en tout ou en partie par le contributeur
+  et qu’il/elle a les droits de publier la contribution sous la licence libre
+  du projet**;<br>
+  ***OU***
+  1. **la contribution a été fournie au contributeur par une autre personne
+  qui certifie la clause #1, et que cette contribution n’a pas été modifiée
+  depuis.**
+
+L’utilisation d’un contrat de licence du contributeur (*CLA*) par le projet est recommandée
+afin de gérer les contributions au projet.  Différentes solutions encadrant la gestion de
+*CLA* dans GitHub sont disponibles:
+* www.clahub.com/
+* cla-assistant.io/
+* clabot.github.io/
+
+### Droits d’auteurs
+
+Les droits d’auteurs pour chaque contribution resteront avec l’auteur original de la
+contribution. 
+
+### Contributions par un responsable du projet
+
+Une modification faite par un responsable du projet et respectant le *CLA* peut être acceptée
+sans plus de formalité.
+
+### Contributions externes
+
+Une contribution par une personne n’étant pas un responsable du projet est considérée
+“externe”, et ce, même si elle est faite par une personne associée à la Ville.  Toute
+contribution externe devra être approuvée par un responsable du projet.  Avant d’accepter
+une contribution, il est de la responsabilité du responsable du projet de s’assurer que:
+1. le *CLA* est respecté,
+1. les licences sont publiées dans les fichiers nécessaires,
+1. la contribution est appropriée et de qualité suffisante.
 
 ## Code de conduite
 
-Le [Code de Conduite](http://ville.montreal.qc.ca/pls/portal/docs/page/intra_fr/media/documents/code_conduite_employes.pdf)
-des employés de la Ville de Montréal s'applique à toutes interactions
-relatives au maintien du projet libre.
+Le maintien de projets libres au nom de la Ville de Montréal affecte potentiellement la
+réputation de la Ville. Il est important de protéger cette réputation pour préserver
+l’image de la Ville. Dans cette optique, toutes interactions avec une communauté libre,
+tant sur les canaux publics (forums, listes de courriels, appels téléphoniques ouverts,
+etc.), qu’en privé (face à face, appels téléphoniques privés, courriels directs, etc.)
+doivent être faites de façon professionnelle, polie et respectueuse, peu importe
+l’attitude des autres parties.
 
 ## Application de la directive
 
-Les étapes à suivre pour faire une publication libre d’un projet de la Ville sont illustrées dans [ce diagramme](https://www.lucidchart.com/documents/view/ce501f7d-1c88-48e4-a2f8-08dd782e6742).
+Les étapes à suivre pour faire une publication libre d’un projet de la Ville sont:
 
-Le processus complet est détaillé par les étapes suivantes :
 1. Identifier une volonté de publication d’un projet en libre.
-1. L’architecte de solutions du projet présente la demande au Comité du Libre
+1. L’architecte de solutions rédige le dossier nécessaire à l’approbation et le présente
+à un directeur du STI, ou à son délégué.
 1. Lorsque la permission est obtenue, l’architecte de solutions désigne le responsable du
 projet chargé de la publication.
 1. Le responsable du projet chargé de la publication prépare le code.  En particulier il
 doit:
-    1. Ajouter les fichiers LICENSE et CONTRIBUTING.md;
+    1. Ajouter les fichiers LICENSE.md et CONTRIBUTING.md;
     1. Enlever toute information privée;
     1. S’assurer que la Ville détient toute la propriété intellectuelle du projet;
+    1. Choisir un outil/processus de *CLA*.
 1. Lorsque le code du projet est prêt, le responsable du projet le publie sous
 github.com/villedemontreal
 1. Le ou les responsables du projet assurent le maintien du projet libre et gèrent
@@ -140,7 +276,7 @@ toutes contributions.
 
 ### Licence MIT globale
 
-Ajoutez le fichier LICENSE dans le le répertoire principal du projet avec le contenu suivant:
+Ajoutez le fichier LICENSE.md dans le le répertoire principal du projet avec le contenu suivant:
 (en ayant remplacé <YEAR> par l’année de publication):
 
 ```
@@ -172,7 +308,7 @@ des commentaires.
 ```
 // Copyright (c) Ville de Montreal. All rights reserved.
 // Licensed under the MIT license.
-// See LICENSE file in the project root for full license information.
+// See LICENSE.md file in the project root for full license information.
 ```
 
 ### Licence ODbL
@@ -212,6 +348,12 @@ open-source soft- and hardware projects on behalf of the city.
 
 ## Definitions
 
+**Contributor License Agreement—CLA**: Agreement between a contributor and the
+legal entity overseeing an open-source project, permitting a contribution to the
+project’s intellectual property.
+
+**Contributor**: Person contributing to an open-source project.
+
 **Contribution**: Any change in code, documentation, configuration files, plans
 or any other files of an open-source project, to be included in the project concerned.
 
@@ -232,25 +374,39 @@ and all physical objects) that have been made public so that anyone can manufact
 modify, distribute or use them.
 
 **Intellectual property**: Legal rights to intellectual creations, such as software
-artifacts or plans for hardware.
+or plans for hardware.
 
-**Open-access publication**: Action of making an
+**Open-access publication**: Efforts and initial steps required to make an
 open-source software or hardware available to the general public.
 
 **Maintainer**: Person responsible for performing all operations considered
 necessary for ensuring the proper operation of an open-source software or hardware
 project, according to established specifications.
 
+## Contribution Permissions
+
+Benefits, risks and costs must be determined before open-access publication of an
+open-source soft- or hardware project. Once the business unit decides that
+open-access project publication is appropriate, permission must be obtained from
+city’s IT director or the latter’s delegate. This permission is intended to ensure
+that the benefits of open-access publication are consistent with municipal values.
+
+Such permission shall be obtained following submission and acceptance of a file
+containing at least the following information:
+1. The product’s purpose.
+1. Market watch document demonstrating any needs to be met or benefits in creating
+a parallel open market.
+1. Prospective risks.
+1. Estimated costs (number of employees assigned to project, tasks required to
+maintain project following publication, estimated period of participation, etc.).
+
 ## Publication
-
-Once a project is identified for open-source publication, working with the
-Open-Source Committee is necessary to start the publication of the project.
-
-An open-source publication will be done in the GitHub organization of the City.
 
 ### Intellectual property
 
-Before making an open-source plublication, a project maintainer must:
+A project maintainer must ensure that the city holds the legal rights for
+open-access publication of a software project on behalf of the city, before such
+publication occurs. The project maintainer does so by:
 1. Ensuring that any files that is to be part of the publication is exclusively
 the city’s intellectual property.<br>
 or
@@ -267,21 +423,51 @@ covered by the Directive on Contributions to an Existing Software Project.
 The project will be published in GitHub under the city’s account at
 github.com/villedemontreal
 
-### Open-Source Project Maintainers
+### Project Maintainers
 
-A project maintainers must be designated prior to publication.
+One or more project maintainers must be designated prior to publication.
 A maintainers should usually have an in-depth understanding of the project
 and will be able to oversee its coding and other features. The project
-maintainer is responsible for managing project evolution to ensure
-that the city can benefit from open-source publication.
+maintainer is responsible for managing project development and ensuring
+that the city can benefit from open-access publication.
+
+We recommend naming more than one maintainer to ensure maintenance of the project.
+
+New maintainers might be appointed over the course of a project, once they have
+demonstrated the necessary abilities for this role. Such an appointment must be
+supported by at least one existing maintainer and not be rejected by any other
+project maintainer. Once an appointment has been approved, the new maintainer
+will have the same rights as the others. A person named as maintainer could be
+someone associated with the city or an external contributor not associated with
+the city.
+
+A project maintainer may abandon this role at any time. Under such circumstances,
+s/he advises the rest of the community to ensure a transition of responsibility,
+if necessary.
+
+### Identity to Use for Publication
+
+One of the assigned project maintainers will handle open-access publication of
+the project. This publication must be performed using the maintainer’s name and
+city email address. Any changes made on behalf of the city following project
+publication must also use the city email address.
+
+Using a city email address makes it possible to distinguish between
+contributions made on behalf of the city from those made outside working hours
+(not paid by the city).
+
+All contributions for which the city owns the intellectual property must be
+made by an employee or contractor working for the city.
+
+All individual contributions must be made using a personal email address.
 
 ### Licence
 
-Any project code published will use the *MIT* license. A LICENSE file, as
+Any project code published will use the MIT license. A LICENSE.md file, as
 defined in Appendix A, must be saved to the project’s base folder following
 initial publication.
 
-A *Creative Commons* license will be used for other project components, such
+A Creative Commons license will be used for other project components, such
 as images and documentation.
 
 The Open Data Commons Open Database License (ODbL) will be used for
@@ -290,27 +476,104 @@ databases (see Appendix A).
 ### Sensitive Information
 
 Open-source publication of a project must comply with Québec’s Privacy Act,
-and must not jeopardize privacy.
+and must not jeopardize privacy, public safety or Montréal’s information
+security.
+
+The project maintainer is responsible for ensuring that the project to be
+published does not contain such information.
+
+A partial list of exceptions follows:
+
+- ***TO BE PROVIDED***
+
+## Contributions
+
+An open-source project is expected to evolve following its publication.
+Internal (municipal) and external (from a contributor not associated with
+the city) contributions are received to fix bugs and add features. These
+contributions must be properly administered.
+
+A project maintainer is responsible for overseeing, accepting and refusing
+contributions.
+
+### Best Practices for Contributions
+
+Project maintainers define the steps to be followed in making a contribution
+to the project. A CONTRIBUTING.md file must be placed in the project’s base
+directory. Best practices for a project are specific to a project and its
+maintainers. Existing CONTRIBUTING.md files may serve as sources of inspiration:
+* github.com/dotnet/corefx/blob/master/Documentation/project-docs/contributing.md
+* github.com/angular/angular.js/blob/master/CONTRIBUTING.md
+* github.com/robbyrussell/oh-my-zsh/blob/master/CONTRIBUTING.md
+* github.com/facebook/react/blob/master/CONTRIBUTING.md
+
+### Licence
+
+Every component of a contribution must have the appropriate licence as defined
+above.
+
+### Contributor License Agreement—CLA
+
+A project maintainer must, in the case of all contributions, ensure that the
+person making them holds the necessary rights to make all the changes requested.
+The contributor does so by specifically confirming that:
+
+  1. **The contribution was written in whole or part by the contributor who holds
+  the rights to publish the contribution under the required open-source licence.**<br>
+  ***OR***
+  1. **The contribution was provided to the contributor by another person who
+  certifies that clause #1 is true, and this contribution has not been subsequently
+  altered.**
+
+We recommend that the project use a contributor licence agreement (CLA) to administer
+contributions to it. Various CLA management solutions may be found in GitHub:
+* www.clahub.com/
+* cla-assistant.io/
+* clabot.github.io/
+
+### Copyright
+
+The copyright for each contribution will remain with the contribution’s original author.
+
+### Contributions by a Project maintainer
+
+A change made by a project maintainer that complies with the CLA may be accepted
+without other formalities.
+
+### External Contributions
+
+A contribution from someone other than a project maintainer is considered “external”
+even if made by a person associated with the city. All external contributions must
+be approved by a project maintainer. Before accepting a contribution, the project
+maintainer must ensure that:
+1. It complies with the CLA.
+1. Licences have been published in the required files.
+1. The contribution is appropriate and of suitable quality.
 
 ## Code of Conduct
 
-The [Code of conduct](http://ville.montreal.qc.ca/pls/portal/docs/page/intra_fr/media/documents/code_conduite_employes.pdf)
-of the City employees applies to all interactions pertaining to open source projects.
+Maintenance of open-source projects on behalf of the city have a potential impact
+on Montréal’s reputation, which must be protected to preserve the city’s image.
+This means that all interactions with an open-source community whether through
+public (forums, email lists, open phone calls, etc.) or private (face-to-face,
+private phone calls, direct emails, etc.) channels must be professional, polite
+and respectful, regardless of the other parties’ attitudes.
 
 ## Application of Directive
 
-The process of publication of a municipal project is illustrated in [this diagram](https://www.lucidchart.com/documents/view/ce501f7d-1c88-48e4-a2f8-08dd782e6742).
+This is how to make open-access publication of a municipal project:
 
-The complete process is detailed below:
 1. Confirm that there is a desire to make open-access publication of a project.
-1. The solutions architect of the project presents the request to the Open-Source Committee.
+1. The solutions architect prepares the file required for approval and submits
+it to an IT director or the latter’s delegate.
 1. Once permission has been obtained, the solutions architect designates the
 project maintainer in charge of publication.
 1. The project maintainer responsible for publication prepares the code. In
 particular, s/he must:
-    1. Add the LICENSE and CONTRIBUTING.md files.
+    1. Add the LICENSE.md and CONTRIBUTING.md files.
     1. Remove all private information.
     1. Make sure the city possesses all of the project’s intellectual property.
+    1. Select a CLA tool/process.
 1. Once the project’s code is ready, the project maintainer publishes it in
 github.com/villedemontreal
 1. The project maintainer(s) ensure(s) maintenance of the open-source project
@@ -320,7 +583,7 @@ and administers all contributions.
 
 ### Global MIT License
 
-Add the file LICENSE to the project’s main folder, using the following
+Add the file LICENSE.md to the project’s main folder, using the following
 content (inserting the year of publication):
 
 ```
@@ -351,7 +614,7 @@ on the programming languages, “//” should be replaced by the appropriate com
 ```
 // Copyright (c) Ville de Montreal. All rights reserved.
 // Licensed under the MIT license.
-// See LICENSE file in the project root for full license information.
+// See LICENSE.md file in the project root for full license information.
 ```
 
 ### ODbL License

--- a/Directives/PublicationProjetVille.md
+++ b/Directives/PublicationProjetVille.md
@@ -14,7 +14,7 @@ de publier un tel projet et de le maintenir.
 
 Cette directive s’adresse à l’ensemble des unités administratives de la
 Ville de Montréal susceptibles d’avoir à publier des projets logiciels
-ou matériels en tant que projet libres.
+ou matériels en tant que projets libres.
 
 Cette directive s’applique autant aux employés de la Ville qu’à ses
 contractants ou aux tierces parties appelées à publier des projets
@@ -52,10 +52,10 @@ dispositifs ou toutes choses physiques) ayant été rendus publics de façon
 artéfacts.
 
 **Propriété intellectuelle**: Droits légaux quant à des créations
-intellectuelles par exemple un logiciel ou des plans de matériels.
+intellectuelles tel que des artéfacts logiciels ou des plans de matériels.
 
-**Publication libre**: Les efforts et étapes initiaux nécessaires
-à rendre un projet logiciel ou matériel disponible au grand public.
+**Publication libre**: Action de rendre un projet logiciel ou 
+matériel disponible au grand public.
 
 **Responsable du projet (*Maintainer*)**: Personne responsable de
 l'exécution de l'ensemble des opérations qui sont jugées nécessaires
@@ -77,18 +77,45 @@ d’un dossier contenant au minimum les éléments suivants :
 1. la vigie de marché démontrant le manque à combler s’il y a lieu,
 ou les avantages de créer un marché ouvert parallèle;
 1. les risques potentiels,
-1. les coûts à prévoir (nombre d’employés affectés aux projet,
+1. les coûts à prévoir (nombre d’employés affectés au projet,
 tâches requises pour le maintien du projet après sa publication,
 estimation de la durée de la participation, etc.).
 
-## Publication
+Une consultation du Comité du Libre est la façon d'entamer la
+publication du projet.
+
+## Gestion d'un projet publié en libre
+
+### Responsable du projet libre
+
+Avant la publication, un ou plusieurs responsables du projet libre
+doivent être désignés.
+Un responsable devrait normalement avoir une connaissance des détails
+du projet et pourra en gérer le code et autres aspects. Le role d’un
+responsable est d'accompagner le projet dans son évolution
+en libre afin que la Ville puisse bénéficier des avantages de la
+publication.
+
+Il est recommandé de désigner plus d’un responsable afin d’assurer le
+maintien du projet.
+
+Durant la vie du projet, de nouveaux responsables peuvent être nommés
+après qu’ils aient démontré les compétences nécessaires pour assurer ce rôle.  Une
+telle nomination doit être appuyée par au moins un responsable existant,
+sans être refusée par aucun autre responsable du projet.  Après une
+nomination approuvée, un nouveau responsable se verra accorder les mêmes
+droits que les responsables existants. Une personne mise en nomination en
+tant que responsable, peut aussi bien être associée à la Ville qu’être un
+contributeur externe, sans aucune association à la Ville.
+
+Un responsable du projet peut en tout temps abandonner officiellement son
+rôle.  Dans un tel cas, il convient d’avertir le reste de la communauté du
+projet, et d’assurer une transition de responsabilité, si nécessaire.
 
 ### Propriété intellectuelle
 
 Afin de pouvoir publier librement un projet logiciel au nom de la
-Ville, un responsable du projet doit s’assurer que la Ville détient
-les droits légaux nécessaires à une telle publication.  Pour cela,
-le responsable du projet doit:
+Ville, un responsable du projet doit:
 1. s’assurer que tout fichier faisant partie de la publication est,
 de façon exclusive, la propriété intellectuelle de la Ville;<br>
 ou,
@@ -103,61 +130,21 @@ Lorsqu’un projet devient disponible en tant que projet libre, toutes
 contributions futures sont régies par la Directive de contribution à
 un projet logiciel existant.
 
-### Forge de logiciels libres
+### Publication initiale
 
-La publication de projet sera faite dans GitHub sous le compte de la 
+La publication initiale du projet sera faite dans GitHub sous le compte de la
 Ville: github.com/villedemontreal
 
-### Responsables du projet
+La publication initiale sera faite par un des responsables du projet.
 
-Avant la publication, un ou plusieurs responsables du projet doivent
-être désignés.  Un responsable devrait normalement avoir une connaissance
-approfondie des détails du projet et pourra en gérer le code et autres
-aspects.  Le mandat d’un responsable du projet est d’assurer l’évolution
-du projet afin que la Ville puisse bénéficier des avantages de la
-publication en libre.
+### Licences
 
-Il est recommandé de désigner plus d’un responsable afin d’assurer le
-maintien du projet.
-
-Durant la vie du projet, de nouveaux responsables peuvent être nommés
-après qu’ils aient démontré les compétences nécessaires pour assurer ce rôle.  Une
-telle nomination doit être appuyée par au moins un responsable existant,
-sans être refusée par aucun autre responsable du projet.  Après une
-nomination approuvée, un nouveau responsable se verra accorder les mêmes
-droits que les responsables existants. Une personne mise en nomination en
-tant que responsable, peut aussi bien être associée à la Ville qu’être un
-contributeur externe, sans aucune association à la Ville.  
-
-Un responsable du projet peut en tout temps abandonner officiellement son
-rôle.  Dans un tel cas, il convient d’avertir le reste de la communauté du
-projet, et d’assurer une transition de responsabilité, si nécessaire.
-
-### Identité à utiliser pour la publication
-
-La publication libre d’un projet sera faite par un des responsables du
-projet qui a été assigné.  Cette publication doit être faite en utilisant
-le nom dudit responsable ainsi que son adresse courriel fournie par la Ville.
-Toutes modifications faites au nom de la Ville, après la publication du projet,
-doivent aussi être faites en utilisant l’adresse courriel fournie par la Ville.
-
-L’utilisation de l’adresse courriel de la Ville permet de distinguer les
-contributions faites au nom de la Ville et de celles réalisées en dehors des
-heures de travail (non rémunérées par la Ville).
-
-Toutes contributions pour lesquelles la Ville possède la propriété intellectuelle
-doivent être faites par un employé ou un contractant à l’emploi de la Ville.
-
-Toutes contributions faites de façon personnelle doivent être faites en utilisant
-une adresse courriel personnelle.
-
-### Licence
-Tout code du projet publié en libre utilisera la licence MIT. Un ficher LICENSE.md
-tel que définit dans l’appendice A, doit être mis dans le répertoire de base du
+Tout code du projet publié en libre utilisera la licence *MIT*. Un ficher LICENSE
+tel que défini dans l’appendice A, doit être mis dans le répertoire de base du
 projet, et ce, dès la publication initiale.
 
 Pour les autres composantes du projet, tel les images et la documentation, une des
-licences Creative Commons sera utilisée.
+licences *Creative Commons* sera utilisée.
 
 Pour les bases de données, la licence *Open Data Commons Open Database License (ODbL)*
 sera utilisée (voir l’appendice A).
@@ -165,15 +152,11 @@ sera utilisée (voir l’appendice A).
 ### Information sensible
 
 Une publication libre d’un projet doit respecter la Loi sur la protection des
-renseignements personnels du Québec; ne pas nuire à la protection de la vie privée
+renseignements personnels du Québec et ne pas nuire à la protection de la vie privée,
 à la sécurité publique ou à la sécurité de l’information de la Ville de Montréal.
 
 Il est de la responsabilité du responsable de projet faisant la publication de
 s’assurer que le projet à publier ne contient pas ce type d’information.
-
-Une liste non-exhaustive d’exceptions est fournie:
-
-- ***À REMPLIR***
 
 ## Contributions
 
@@ -184,6 +167,18 @@ contributions doivent être gérées de façon adéquate.
 
 Il est de la responsabilité d’un responsable du projet de gérer et d’accepter ou
 refuser une contribution.
+
+### Identité à utiliser pour contributions
+
+Toutes contributions pour lesquelles la Ville possède la propriété intellectuelle
+doivent être faites par un employé ou un contractant à l’emploi de la Ville.
+
+Toutes contributions faites au nom de la Ville, après la publication du projet,
+doivent être faites en utilisant une adresse courriel fournie par la Ville, dans
+les commits Git.
+
+Toutes contributions faites par un employé de la Ville mais de façon personnelle
+doivent être faites en utilisant une adresse courriel personnelle dans les commits Git.
 
 ### Bonnes pratiques pour contributions
 
@@ -200,7 +195,7 @@ servir d’inspiration:
 ### Licence
 
 Chaque composante faisant partie d’une contribution devra utiliser la licence appropriée
-comme définie plus haut. 
+comme définie plus haut.
 
 ### Contrat de licence du contributeur (*Contributor License Agreement - CLA*)
 Dans tous les cas de contributions, un responsable du projet doit s’assurer que la personne
@@ -225,7 +220,7 @@ afin de gérer les contributions au projet.  Différentes solutions encadrant la
 ### Droits d’auteurs
 
 Les droits d’auteurs pour chaque contribution resteront avec l’auteur original de la
-contribution. 
+contribution.
 
 ### Contributions par un responsable du projet
 
@@ -244,26 +239,26 @@ une contribution, il est de la responsabilité du responsable du projet de s’a
 
 ## Code de conduite
 
-Le maintien de projets libres au nom de la Ville de Montréal affecte potentiellement la
-réputation de la Ville. Il est important de protéger cette réputation pour préserver
-l’image de la Ville. Dans cette optique, toutes interactions avec une communauté libre,
-tant sur les canaux publics (forums, listes de courriels, appels téléphoniques ouverts,
-etc.), qu’en privé (face à face, appels téléphoniques privés, courriels directs, etc.)
-doivent être faites de façon professionnelle, polie et respectueuse, peu importe
-l’attitude des autres parties.
+Le [Code de Conduite](http://ville.montreal.qc.ca/pls/portal/docs/page/intra_fr/media/documents/code_conduite_employes.pdf)
+des employés de la Ville de Montréal s'applique à toutes interactions
+relatives au maintien du projet libre.
 
 ## Application de la directive
 
-Les étapes à suivre pour faire une publication libre d’un projet de la Ville sont:
+Les étapes à suivre pour faire une publication libre d’un projet de la Ville sont illustrées dans
+[ce diagramme](https://www.lucidchart.com/documents/view/ce501f7d-1c88-48e4-a2f8-08dd782e6742).
 
-1. Identifier une volonté de publication d’un projet en libre.
-1. L’architecte de solutions rédige le dossier nécessaire à l’approbation et le présente
-à un directeur du STI, ou à son délégué.
+Le processus complet est détaillé par les étapes suivantes :
+1. Identifier une volonté de publication d’un projet en libre;
+1. L’architecte de solutions du projet rédige le dossier nécessaire à l’approbation et le présente
+au Comité du Libre;
+1. Le Comité du Libre accompagne l'architecte de solutions dans sa demande d'approbation
+au directeur du service des TI ou de son délégué;
 1. Lorsque la permission est obtenue, l’architecte de solutions désigne le responsable du
 projet chargé de la publication.
 1. Le responsable du projet chargé de la publication prépare le code.  En particulier il
 doit:
-    1. Ajouter les fichiers LICENSE.md et CONTRIBUTING.md;
+    1. Ajouter les fichiers LICENSE et CONTRIBUTING.md;
     1. Enlever toute information privée;
     1. S’assurer que la Ville détient toute la propriété intellectuelle du projet;
     1. Choisir un outil/processus de *CLA*.
@@ -276,7 +271,7 @@ toutes contributions.
 
 ### Licence MIT globale
 
-Ajoutez le fichier LICENSE.md dans le le répertoire principal du projet avec le contenu suivant:
+Ajoutez le fichier LICENSE dans le le répertoire principal du projet avec le contenu suivant:
 (en ayant remplacé <YEAR> par l’année de publication):
 
 ```
@@ -308,7 +303,7 @@ des commentaires.
 ```
 // Copyright (c) Ville de Montreal. All rights reserved.
 // Licensed under the MIT license.
-// See LICENSE.md file in the project root for full license information.
+// See LICENSE file in the project root for full license information.
 ```
 
 ### Licence ODbL
@@ -374,9 +369,9 @@ and all physical objects) that have been made public so that anyone can manufact
 modify, distribute or use them.
 
 **Intellectual property**: Legal rights to intellectual creations, such as software
-or plans for hardware.
+artifacts or plans for hardware.
 
-**Open-access publication**: Efforts and initial steps required to make an
+**Open-access publication**: Action of making an
 open-source software or hardware available to the general public.
 
 **Maintainer**: Person responsible for performing all operations considered
@@ -388,7 +383,7 @@ project, according to established specifications.
 Benefits, risks and costs must be determined before open-access publication of an
 open-source soft- or hardware project. Once the business unit decides that
 open-access project publication is appropriate, permission must be obtained from
-city’s IT director or the latter’s delegate. This permission is intended to ensure
+city’s IT director or his delegate. This permission is intended to ensure
 that the benefits of open-access publication are consistent with municipal values.
 
 Such permission shall be obtained following submission and acceptance of a file
@@ -400,36 +395,18 @@ a parallel open market.
 1. Estimated costs (number of employees assigned to project, tasks required to
 maintain project following publication, estimated period of participation, etc.).
 
-## Publication
+Contacting the Open-Source Committee is the way to start the process of
+publication of the project.
 
-### Intellectual property
+### Management of a published project
 
-A project maintainer must ensure that the city holds the legal rights for
-open-access publication of a software project on behalf of the city, before such
-publication occurs. The project maintainer does so by:
-1. Ensuring that any files that is to be part of the publication is exclusively
-the city’s intellectual property.<br>
-or
-1. Ensuring that the city holds the necessary rights to publish all files to be
-included in the publication under the open-source licence concerned (see the
-Licence section).
-Open-source publication of the project is done on behalf of city to the public
-repository specified by IT.
-If a project is accepted as open source, all future contributions to it are
-covered by the Directive on Contributions to an Existing Software Project.
-
-### Open-Source Software Registry
-
-The project will be published in GitHub under the city’s account at
-github.com/villedemontreal
-
-### Project Maintainers
+### Open-Source Project Maintainers
 
 One or more project maintainers must be designated prior to publication.
 A maintainers should usually have an in-depth understanding of the project
 and will be able to oversee its coding and other features. The project
-maintainer is responsible for managing project development and ensuring
-that the city can benefit from open-access publication.
+maintainer is responsible for managing project evolution to ensure
+that the city can benefit from open-source publication.
 
 We recommend naming more than one maintainer to ensure maintenance of the project.
 
@@ -445,32 +422,39 @@ A project maintainer may abandon this role at any time. Under such circumstances
 s/he advises the rest of the community to ensure a transition of responsibility,
 if necessary.
 
-### Identity to Use for Publication
+### Intellectual property
 
-One of the assigned project maintainers will handle open-access publication of
-the project. This publication must be performed using the maintainer’s name and
-city email address. Any changes made on behalf of the city following project
-publication must also use the city email address.
+Before making an open-source plublication, a project maintainer must:
+1. Ensuring that any files that is to be part of the publication is exclusively
+the city’s intellectual property.<br>
+or
+1. Ensuring that the city holds the necessary rights to publish all files to be
+included in the publication under the open-source licence concerned (see the
+Licence section).
 
-Using a city email address makes it possible to distinguish between
-contributions made on behalf of the city from those made outside working hours
-(not paid by the city).
+Open-source publication of the project is done on behalf of city to the public
+repository specified by IT.
 
-All contributions for which the city owns the intellectual property must be
-made by an employee or contractor working for the city.
+If a project is accepted as open source, all future contributions to it are
+covered by the Directive on Contributions to an Existing Software Project.
 
-All individual contributions must be made using a personal email address.
+### Initial publication
 
-### Licence
+The project will be published in GitHub under the city’s account at
+github.com/villedemontreal
 
-Any project code published will use the MIT license. A LICENSE.md file, as
+The initial publication will be done by a projet maintainer.
+
+### Licences
+
+Any project code published will use the *MIT* license. A LICENSE file, as
 defined in Appendix A, must be saved to the project’s base folder following
 initial publication.
 
-A Creative Commons license will be used for other project components, such
+A *Creative Commons* license will be used for other project components, such
 as images and documentation.
 
-The Open Data Commons Open Database License (ODbL) will be used for
+The *Open Data Commons Open Database License (ODbL)* will be used for
 databases (see Appendix A).
 
 ### Sensitive Information
@@ -482,10 +466,6 @@ security.
 The project maintainer is responsible for ensuring that the project to be
 published does not contain such information.
 
-A partial list of exceptions follows:
-
-- ***TO BE PROVIDED***
-
 ## Contributions
 
 An open-source project is expected to evolve following its publication.
@@ -495,6 +475,17 @@ contributions must be properly administered.
 
 A project maintainer is responsible for overseeing, accepting and refusing
 contributions.
+
+### Identity to Use for Publication
+
+All contributions for which the city owns the intellectual property must be
+made by an employee or contractor working for the city.
+
+All contributions made on behalf of the city, after the publication of the
+project, must be made using a city-provided email address in the Git commits.
+
+All personal contributions made by a city employee must be made using a
+personal email address in the Git commits.
 
 ### Best Practices for Contributions
 
@@ -552,25 +543,25 @@ maintainer must ensure that:
 
 ## Code of Conduct
 
-Maintenance of open-source projects on behalf of the city have a potential impact
-on Montréal’s reputation, which must be protected to preserve the city’s image.
-This means that all interactions with an open-source community whether through
-public (forums, email lists, open phone calls, etc.) or private (face-to-face,
-private phone calls, direct emails, etc.) channels must be professional, polite
-and respectful, regardless of the other parties’ attitudes.
+The [Code of conduct](http://ville.montreal.qc.ca/pls/portal/docs/page/intra_fr/media/documents/code_conduite_employes.pdf)
+of the City employees applies to all interactions pertaining to open source projects.
 
 ## Application of Directive
 
-This is how to make open-access publication of a municipal project:
+The process of publication of a municipal project is illustrated in
+[this diagram](https://www.lucidchart.com/documents/view/ce501f7d-1c88-48e4-a2f8-08dd782e6742).
 
-1. Confirm that there is a desire to make open-access publication of a project.
-1. The solutions architect prepares the file required for approval and submits
-it to an IT director or the latter’s delegate.
+The complete process is detailed below:
+1. Identify a desire to make an open-source publication of a project.
+1. The solutions architect of the project prepares the file required for approval
+and presents the request to the Open-Source Committee.
+1. The Open-Source Committee works with the solutions architect in the approval
+request made to the IT director or his delegate.
 1. Once permission has been obtained, the solutions architect designates the
 project maintainer in charge of publication.
 1. The project maintainer responsible for publication prepares the code. In
-particular, s/he must:
-    1. Add the LICENSE.md and CONTRIBUTING.md files.
+particular, he must:
+    1. Add the LICENSE and CONTRIBUTING.md files.
     1. Remove all private information.
     1. Make sure the city possesses all of the project’s intellectual property.
     1. Select a CLA tool/process.
@@ -583,7 +574,7 @@ and administers all contributions.
 
 ### Global MIT License
 
-Add the file LICENSE.md to the project’s main folder, using the following
+Add the file LICENSE to the project’s main folder, using the following
 content (inserting the year of publication):
 
 ```
@@ -614,7 +605,7 @@ on the programming languages, “//” should be replaced by the appropriate com
 ```
 // Copyright (c) Ville de Montreal. All rights reserved.
 // Licensed under the MIT license.
-// See LICENSE.md file in the project root for full license information.
+// See LICENSE file in the project root for full license information.
 ```
 
 ### ODbL License


### PR DESCRIPTION
Voici le revert aux anciennes versions des directives, mais en gardant les changements mineurs.

Pour voir les différences par rapport aux directives originales voici un diff:
https://github.com/VilledeMontreal/politique-libre/commit/7b5eaa5ae59fc8f4e29cb4990957786cd99b3928

Prêter attention particulière à des nouvelles modifications faites dans une section maintenant intitulée: "Gestion d'un projet publié en libre" qui était auparavant "Publication"